### PR TITLE
refactor: remove DEFLATE algorithm support from compression utilities and documentation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A robust utility for archiving, compressing, and signing web applications for cr
 ## Features
 
 - **📦 Archiving**: Preserve directory structures with metadata
-- **🗜️ Compression**: Multiple algorithms (GZIP, Brotli, DEFLATE)
+- **🗜️ Compression**: Multiple algorithms (GZIP, Brotli)
 - **🔑 Cryptography**: Ed25519 signing and verification
 - **🖥️ CLI**: Intuitive command-line interface
 - **⚡ API**: Fully typed, promise-based API
@@ -252,7 +252,7 @@ await compressFile('./input.txt', './output.txt.gz', {
 ```
 
 **Options:**
-- `algorithm`: Compression algorithm (`GZIP`, `BROTLI`, or `DEFLATE`)
+- `algorithm`: Compression algorithm (`GZIP` or `BROTLI`)
 - `level`: Compression level (1-9, higher is better compression but slower)
 
 #### `decompressFile(sourcePath: string, outputPath: string, options?: { algorithm?: CompressionAlgorithm }): Promise<void>`
@@ -353,7 +353,6 @@ try {
 |-----------|----------|-------------|-------|----------------|
 | GZIP      | General use | Good | Fast | Widely supported |
 | Brotli    | Web content | Excellent | Medium | Modern browsers |
-| DEFLATE   | Legacy systems | Good | Fast | Universal |
 
 ### Memory Usage
 
@@ -447,31 +446,10 @@ The archive format is designed to be simple, efficient, and extensible:
 
 The packager supports multiple compression algorithms. The choice of algorithm can impact both the size of the compressed data and the performance of compression and decompression. Native platform support for decompression is a key factor in selecting an algorithm for optimal performance.
 
-### **DEFLATE**
-
-* **Description:**
-    * A lossless data compression algorithm that uses a combination of LZ77 and Huffman coding. It is the core algorithm for GZIP and ZIP.
-* **Best For Compression:**
-    * Good balance between compression ratio and speed; scenarios requiring low overhead.
-* **Native Decompression Support & Best Fit for Decompression:**
-    * **Windows (C#/.NET):**
-        * Native support via `System.IO.Compression.DeflateStream`.
-        * Fits well when decompressing data from GZIP or ZIP archives, or when a lightweight, fast decompression is needed.
-    * **Linux (Python with GTK):**
-        * Native support via the `zlib` standard library.
-        * Excellent fit for general-purpose decompression where `zlib` is readily available.
-    * **Android (Java/Kotlin):**
-        * Native support via `java.util.zip.InflaterInputStream` or `java.util.zip.Inflater`.
-        * A good choice for decompressing ZIP files or raw DEFLATE streams.
-    * **iOS/macOS (Swift):**
-        * Native support via Apple's Compression framework (using `Algorithm.zlib` or the C-level `COMPRESSION_ZLIB`).
-        * Ideal for decompressing raw DEFLATE streams or as the core for handling GZIP/ZIP data.
-
-
 ### **GZIP**
 
 * **Description:**
-    * Based on DEFLATE, it adds a header and trailer with metadata, including a CRC32 checksum for error detection. Good compression ratio and widely compatible.
+    * A widely-used compression format that adds headers and trailers with metadata, including a CRC32 checksum for error detection. Good compression ratio and widely compatible.
 * **Best For Compression:**
     * General-purpose usage, especially for web content and file transfer where compatibility and integrity checks are valued.
 * **Native Decompression Support & Best Fit for Decompression:**
@@ -485,7 +463,7 @@ The packager supports multiple compression algorithms. The choice of algorithm c
         * Native support via `java.util.zip.GZIPInputStream`.
         * Commonly used for decompressing web responses and `.gz` files.
     * **iOS/macOS (Swift):**
-        * Native support by using Apple's Compression framework with `Algorithm.zlib` (DEFLATE) and manually handling GZIP headers/trailers, or by leveraging common system libraries that wrap zlib for GZIP.
+        * Native support by using Apple's Compression framework with `Algorithm.zlib` and manually handling GZIP headers/trailers, or by leveraging common system libraries that wrap zlib for GZIP.
         * Fits well for decompressing `.gz` files and GZIP-encoded web data.
 
 
@@ -503,7 +481,7 @@ The packager supports multiple compression algorithms. The choice of algorithm c
         * Native decompression typically requires external libraries (e.g., `brotli` PyPI package).
         * Fits best when the environment is set up with these dependencies and maximum decompression ratio benefits are sought.
     * **Android (Java/Kotlin):**
-        * Native support is less direct for general app development compared to DEFLATE/GZIP; often available via WebView for web content or through JNI with Brotli libraries.
+        * Native support is less direct for general app development compared to GZIP; often available via WebView for web content or through JNI with Brotli libraries.
         * Best fit for decompressing Brotli-encoded content within web contexts or when specifically integrating a Brotli library.
     * **iOS/macOS (Swift):**
         * Native support via Apple's Compression framework (using `Algorithm.brotli` or C-level `COMPRESSION_BROTLI`, available iOS 13+/macOS 10.15+; C API availability might be iOS 15+ for some uses, requiring OS version checks).

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -52,7 +52,7 @@ program
   .description('Compress a file or directory')
   .argument('<source>', 'Source file or directory to compress')
   .argument('<output>', 'Output compressed file path')
-  .option('-a, --algorithm <algorithm>', 'Compression algorithm (gzip, brotli, deflate)')
+  .option('-a, --algorithm <algorithm>', 'Compression algorithm (gzip, brotli)')
   .option('-l, --level <level>', 'Compression level (1-9)')
   .option('--archive', 'Archive the directory before compression if source is a directory')
   .option('-i, --include <pattern>', 'Include file pattern for archiving (glob), comma-separated')
@@ -69,7 +69,7 @@ program
   .description('Decompress a file')
   .argument('<source>', 'Source compressed file')
   .argument('<output>', 'Output decompressed file path or directory')
-  .option('-a, --algorithm <algorithm>', 'Compression algorithm (gzip, brotli, deflate)')
+  .option('-a, --algorithm <algorithm>', 'Compression algorithm (gzip, brotli)')
   .option('--unarchive', 'Unarchive the decompressed file if it is an archive')
   .action(handleDecompress);
 
@@ -134,7 +134,7 @@ program
   .description('Archive, compress, and optionally sign a directory into a single file')
   .argument('<source>', 'Source directory to package')
   .argument('<output>', 'Output file path for the compressed file')
-  .option('-a, --algorithm <algorithm>', 'Compression algorithm (gzip, brotli, deflate)')
+  .option('-a, --algorithm <algorithm>', 'Compression algorithm (gzip, brotli)')
   .option('--privkey <path>', 'Path to the private key file for signing')
   .action(handlePackage);
 

--- a/src/compression.ts
+++ b/src/compression.ts
@@ -24,8 +24,6 @@ const gzip = promisify(zlib.gzip);
 const gunzip = promisify(zlib.gunzip);
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
-const deflate = promisify(zlib.deflate);
-const inflate = promisify(zlib.inflate);
 
 /**
  * Compresses data using the specified algorithm
@@ -42,7 +40,7 @@ export async function compressData(
 
   // Validate compression level based on algorithm
   if (level < 0 || level > (options.algorithm === CompressionAlgorithm.BROTLI ? 11 : 9)) {
-    throw new RangeError(`Invalid compression level ${level}. Expected 0-9 (gzip/deflate) or 0-11 (brotli).`);
+    throw new RangeError(`Invalid compression level ${level}. Expected 0-9 (gzip) or 0-11 (brotli).`);
   }
 
   // Compress based on algorithm
@@ -55,8 +53,6 @@ export async function compressData(
         [zlib.constants.BROTLI_PARAM_QUALITY]: level,
       },
     });
-  case CompressionAlgorithm.DEFLATE:
-    return await deflate(data, { level });
   default:
     throw new Error(`Unsupported compression algorithm: ${options.algorithm}`);
   }
@@ -79,8 +75,6 @@ export async function decompressData(
       return gunzip(data);
     case CompressionAlgorithm.BROTLI:
       return brotliDecompress(data);
-    case CompressionAlgorithm.DEFLATE:
-      return inflate(data);
     default:
       throw new Error(`Unsupported compression algorithm: ${algorithm}`);
     }
@@ -100,8 +94,7 @@ export async function decompressData(
       // Brotli decompression failed
     }
 
-    // Don't try DEFLATE as fallback since it's error-prone when used blindly
-    // DEFLATE doesn't have a consistent signature and can lead to false positives
+    // Unable to detect compression format
     throw new Error('Unable to detect compression algorithm. Please specify the algorithm explicitly.');
   } catch (error) {
     if (error instanceof Error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,8 +30,6 @@ export enum CompressionAlgorithm {
   GZIP = 'gzip',
   /** Good for C#/.NET (Windows apps) in terms of compression ratio */
   BROTLI = 'brotli',
-  /** Raw DEFLATE compression, widely compatible with most platforms, slightly less overhead than GZIP */
-  DEFLATE = 'deflate',
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,6 @@ import { signFile } from './crypto.js';
 export const algorithmToExtension: Record<CompressionAlgorithm, string> = {
   [CompressionAlgorithm.GZIP]: '.gz',
   [CompressionAlgorithm.BROTLI]: '.br',
-  [CompressionAlgorithm.DEFLATE]: '.deflate'
 };
 
 /**
@@ -23,7 +22,6 @@ export const extensionToAlgorithm: Record<string, CompressionAlgorithm> = {
   '.gzip': CompressionAlgorithm.GZIP,
   '.br': CompressionAlgorithm.BROTLI,
   '.brotli': CompressionAlgorithm.BROTLI,
-  '.deflate': CompressionAlgorithm.DEFLATE,
 };
 
 const mkdir = promisify(fs.mkdir);
@@ -103,8 +101,6 @@ export function getCompressionAlgorithm(algorithm: string): CompressionAlgorithm
     return CompressionAlgorithm.GZIP;
   case 'brotli':
     return CompressionAlgorithm.BROTLI;
-  case 'deflate':
-    return CompressionAlgorithm.DEFLATE;
   default:
     throw new Error(`Unsupported compression algorithm: ${algorithm}`);
   }

--- a/vitest/cli/commands/common.test.ts
+++ b/vitest/cli/commands/common.test.ts
@@ -51,8 +51,7 @@ export function setupMocks(): void {
     getCompressionAlgorithm: vi.fn(() => 'gzip'),
     CompressionAlgorithm: {
       GZIP: 'gzip',
-      BROTLI: 'brotli',
-      DEFLATE: 'deflate'
+      BROTLI: 'brotli'
     }
   }));
 

--- a/vitest/cli/index.test.ts
+++ b/vitest/cli/index.test.ts
@@ -123,7 +123,7 @@ describe('CLI Index Module', () => {
 
     expect(mockCommand.option).toHaveBeenCalledWith('-i, --include <pattern>', expect.any(String));
     expect(mockCommand.option).toHaveBeenCalledWith('-e, --exclude <pattern>', expect.any(String));
-    expect(mockCommand.option).toHaveBeenCalledWith('-a, --algorithm <algorithm>', expect.stringContaining('gzip, brotli, deflate'));
+    expect(mockCommand.option).toHaveBeenCalledWith('-a, --algorithm <algorithm>', expect.stringContaining('gzip, brotli'));
     expect(mockCommand.option).toHaveBeenCalledWith('-l, --level <level>', expect.any(String));
 
     expect(mockCommand.requiredOption).toHaveBeenCalledWith('--privkey <path>', expect.any(String));
@@ -195,7 +195,7 @@ describe('CLI Index Module', () => {
     expect(mockProgram.command).toHaveBeenCalledWith('compress');
     expect(mockCommand.alias).toHaveBeenCalledWith('c');
     expect(mockCommand.description).toHaveBeenCalledWith('Compress a file or directory');
-    expect(mockCommand.option).toHaveBeenCalledWith('-a, --algorithm <algorithm>', expect.stringContaining('gzip, brotli, deflate'));
+    expect(mockCommand.option).toHaveBeenCalledWith('-a, --algorithm <algorithm>', expect.stringContaining('gzip, brotli'));
     expect(mockCommand.option).toHaveBeenCalledWith('-l, --level <level>', expect.any(String));
   });
 
@@ -206,7 +206,7 @@ describe('CLI Index Module', () => {
     expect(mockProgram.command).toHaveBeenCalledWith('package');
     expect(mockCommand.alias).toHaveBeenCalledWith('pkg');
     expect(mockCommand.description).toHaveBeenCalledWith('Archive, compress, and optionally sign a directory into a single file');
-    expect(mockCommand.option).toHaveBeenCalledWith('-a, --algorithm <algorithm>', expect.stringContaining('gzip, brotli, deflate'));
+    expect(mockCommand.option).toHaveBeenCalledWith('-a, --algorithm <algorithm>', expect.stringContaining('gzip, brotli'));
     expect(mockCommand.option).toHaveBeenCalledWith('--privkey <path>', expect.any(String));
   });
 });

--- a/vitest/compression/compression.test.ts
+++ b/vitest/compression/compression.test.ts
@@ -13,10 +13,7 @@ describe('Compression Module', () => {
       [CompressionAlgorithm.GZIP, 9],
       [CompressionAlgorithm.BROTLI, undefined],
       [CompressionAlgorithm.BROTLI, 1],
-      [CompressionAlgorithm.BROTLI, 9],
-      [CompressionAlgorithm.DEFLATE, undefined],
-      [CompressionAlgorithm.DEFLATE, 1],
-      [CompressionAlgorithm.DEFLATE, 9],
+      [CompressionAlgorithm.BROTLI, 9]
     ])('should compress and decompress correctly with %s algorithm and level %s', async (algorithm, level) => {
       // Compress data
       const compressed = await compressData(testData, { algorithm, level });
@@ -66,19 +63,19 @@ describe('Compression Module', () => {
     it('should throw error for invalid compression level with GZIP', async () => {
       await expect(
         compressData(testData, { algorithm: CompressionAlgorithm.GZIP, level: 12 })
-      ).rejects.toThrow('Invalid compression level 12. Expected 0-9 (gzip/deflate) or 0-11 (brotli)');
+      ).rejects.toThrow('Invalid compression level 12. Expected 0-9 (gzip) or 0-11 (brotli)');
     });
 
     it('should throw error for invalid compression level with BROTLI', async () => {
       await expect(
         compressData(testData, { algorithm: CompressionAlgorithm.BROTLI, level: 15 })
-      ).rejects.toThrow('Invalid compression level 15. Expected 0-9 (gzip/deflate) or 0-11 (brotli)');
+      ).rejects.toThrow('Invalid compression level 15. Expected 0-9 (gzip) or 0-11 (brotli)');
     });
 
     it('should throw error for negative compression level', async () => {
       await expect(
         compressData(testData, { algorithm: CompressionAlgorithm.GZIP, level: -1 })
-      ).rejects.toThrow('Invalid compression level -1. Expected 0-9 (gzip/deflate) or 0-11 (brotli)');
+      ).rejects.toThrow('Invalid compression level -1. Expected 0-9 (gzip) or 0-11 (brotli)');
     });
 
     it('should support auto-detection of GZIP compression format', async () => {

--- a/vitest/compression/file-compression.test.ts
+++ b/vitest/compression/file-compression.test.ts
@@ -61,8 +61,7 @@ describe('File Compression', () => {
 
   it.each([
     CompressionAlgorithm.GZIP,
-    CompressionAlgorithm.BROTLI,
-    CompressionAlgorithm.DEFLATE,
+    CompressionAlgorithm.BROTLI
   ])('should work with %s algorithm', async (algorithm) => {
     // Create test file
     const testContent = 'Test content for compression';
@@ -75,7 +74,7 @@ describe('File Compression', () => {
     // Compress file
     await compressFile(inputPath, compressedPath, { algorithm });
 
-    // Decompress file with explicit algorithm (as auto-detection for DEFLATE is disabled)
+    // Decompress file with explicit algorithm
     await decompressFile(compressedPath, outputPath, algorithm);
 
     // Verify content is the same
@@ -173,18 +172,18 @@ describe('File Compression', () => {
     // Create test file
     const testContent = 'Test content for explicit algorithm decompression';
     const inputPath = path.join(tempDir, 'explicit-algo-input.txt');
-    const compressedPath = path.join(tempDir, 'explicit-algo.deflate');
+    const compressedPath = path.join(tempDir, 'explicit-algo.br');
     const outputPath = path.join(tempDir, 'explicit-algo-output.txt');
 
     await writeFile(inputPath, testContent);
 
-    // Compress file with DEFLATE
+    // Compress file with BROTLI
     await compressFile(inputPath, compressedPath, {
-      algorithm: CompressionAlgorithm.DEFLATE
+      algorithm: CompressionAlgorithm.BROTLI
     });
 
     // Decompress file with explicit algorithm
-    await decompressFile(compressedPath, outputPath, CompressionAlgorithm.DEFLATE);
+    await decompressFile(compressedPath, outputPath, CompressionAlgorithm.BROTLI);
 
     // Verify content is the same
     const outputContent = await readFile(outputPath, 'utf8');
@@ -197,31 +196,25 @@ describe('File Compression', () => {
     const inputPath = path.join(tempDir, 'ext-detect-input.txt');
     const gzipPath = path.join(tempDir, 'ext-detect.gz');
     const brotliPath = path.join(tempDir, 'ext-detect.br');
-    const deflatePath = path.join(tempDir, 'ext-detect.deflate');
 
     await writeFile(inputPath, testContent);
 
     // Compress with different algorithms
     await compressFile(inputPath, gzipPath, { algorithm: CompressionAlgorithm.GZIP });
     await compressFile(inputPath, brotliPath, { algorithm: CompressionAlgorithm.BROTLI });
-    await compressFile(inputPath, deflatePath, { algorithm: CompressionAlgorithm.DEFLATE });
 
     // Decompress with auto-detection by extension
     const gzipOutput = path.join(tempDir, 'ext-detect-gzip-output.txt');
     const brotliOutput = path.join(tempDir, 'ext-detect-brotli-output.txt');
-    const deflateOutput = path.join(tempDir, 'ext-detect-deflate-output.txt');
 
     await decompressFile(gzipPath, gzipOutput);
     await decompressFile(brotliPath, brotliOutput);
-    await decompressFile(deflatePath, deflateOutput);
 
     // Verify content is the same for all
     const gzipContent = await readFile(gzipOutput, 'utf8');
     const brotliContent = await readFile(brotliOutput, 'utf8');
-    const deflateContent = await readFile(deflateOutput, 'utf8');
 
     expect(gzipContent).toBe(testContent);
     expect(brotliContent).toBe(testContent);
-    expect(deflateContent).toBe(testContent);
   });
 });

--- a/vitest/utils/create-package.test.ts
+++ b/vitest/utils/create-package.test.ts
@@ -105,8 +105,7 @@ describe('createPackage', () => {
     // Test with all supported algorithms
     for (const algorithm of [
       CompressionAlgorithm.GZIP,
-      CompressionAlgorithm.BROTLI,
-      CompressionAlgorithm.DEFLATE
+      CompressionAlgorithm.BROTLI
     ]) {
       const outputPath = path.join(outputDir, `test-${algorithm}-package`);
 

--- a/vitest/utils/get-compression-algorithm.test.ts
+++ b/vitest/utils/get-compression-algorithm.test.ts
@@ -17,13 +17,6 @@ describe('getCompressionAlgorithm', () => {
     expect(getCompressionAlgorithm('BrOtLi')).toBe(CompressionAlgorithm.BROTLI);
   });
 
-  it('returns correct compression algorithm for DEFLATE', () => {
-    expect(getCompressionAlgorithm('deflate')).toBe(CompressionAlgorithm.DEFLATE);
-    expect(getCompressionAlgorithm('DEFLATE')).toBe(CompressionAlgorithm.DEFLATE);
-    expect(getCompressionAlgorithm('Deflate')).toBe(CompressionAlgorithm.DEFLATE);
-    expect(getCompressionAlgorithm('DeFlAtE')).toBe(CompressionAlgorithm.DEFLATE);
-  });
-
   it('throws error for invalid compression algorithm', () => {
     expect(() => getCompressionAlgorithm('invalid')).toThrow(
       'Unsupported compression algorithm: invalid'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed support for the DEFLATE compression algorithm from all user-facing features, including the CLI and documentation. Only GZIP and Brotli are now available for compression and decompression.

- **Documentation**
  - Updated all documentation and help texts to remove references to DEFLATE and clarify supported algorithms.

- **Tests**
  - Removed all test cases and references related to DEFLATE, ensuring tests only cover GZIP and Brotli.

- **Chores**
  - Added a new GitHub Actions workflow to enable automated interactions with the Claude AI system triggered by specific mentions in GitHub discussions or reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->